### PR TITLE
 Update: Include sample_name IRIDA-Next input column

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -42,17 +42,32 @@ jobs:
           python-version: "3.11"
           architecture: "x64"
 
+      - name: read .nf-core.yml
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: read_yml
+        with:
+          config: ${{ github.workspace }}/.nf-core.yml
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install nf-core
+          pip install nf-core==${{ steps.read_yml.outputs['nf_core_version'] }}
 
-      - name: Run nf-core lint
+      - name: Run nf-core pipelines lint
+        if: ${{ github.base_ref != 'main' }}
         env:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
-        run: nf-core -l lint_log.txt lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
+        run: nf-core -l lint_log.txt pipelines lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
+
+      - name: Run nf-core pipelines lint --release
+        if: ${{ github.base_ref == 'master' }}
+        env:
+          GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
+        run: nf-core -l lint_log.txt pipelines lint --release --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
 
       - name: Save PR number
         if: ${{ always() }}

--- a/.github/workflows/linting_comment.yml
+++ b/.github/workflows/linting_comment.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download lint results
-        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: linting.yml
           workflow_conclusion: completed

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -32,5 +32,8 @@ lint:
     - custom_config
     - manifest.name
     - manifest.homePage
+    - params.max_cpus
+    - params.max_memory
+    - params.max_time
   readme:
     - nextflow_badge

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,4 +1,5 @@
 repository_type: pipeline
+nf_core_version: "3.0.1"
 
 lint:
   files_exist:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added the ability to include a `sample_name` column in the input samplesheet.csv. Allows for compatibility with IRIDA-Next input configuration.
+  - `sample_name` special characters will be replaced with `"_"`
+  - If no `sample_name` is supplied in the column `sample` will be used
+  - To avoid repeat values for `sample_name` all `sample_name` values will be suffixed with the unique `sample` value from the input file
 
 ## [0.2.0] - 2024-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Development
+
+### Changed
+
+- Added the ability to include a `sample_name` column in the input samplesheet.csv. Allows for compatibility with IRIDA-Next input configuration.
+
 ## [0.2.0] - 2024-09-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ An example of the sample sheet is available in [tests/data/samplesheets/samplesh
 
 Furthermore, the structure of the sample sheet is programmatically defined in [assets/schema_input.json](assets/schema_input.json). Validation of the sample sheet is performed by [nf-validation](https://nextflow-io.github.io/nf-validation/).
 
+## IRIDA-Next Optional Input Configuration
+
+`arboratornf` accepts the [IRIDA-Next](https://github.com/phac-nml/irida-next) format for samplesheets which can contain an additional column: `sample_name`
+
+`sample_name`: An **optional** column, that overrides `sample` for outputs (filenames and sample names) and reference assembly identification.
+
+`sample_name`, allows more flexibility in naming output files or sample identification. Unlike `sample`, `sample_name` is not required to contain unique values. `Nextflow` requires unique sample names, and therefore in the instance of repeat `sample_names`, `sample` will be suffixed to any `sample_name`. Non-alphanumeric characters (excluding `_`,`-`,`.`) will be replaced with `"_"`.
+
+An [example samplesheet](../tests/data/samplesheets/samplesheet-samplename.csv) has been provided with the pipeline.
+
 # Parameters
 
 The mandatory parameters are `--input`, which specifies the samplesheet as described above, and `--output`, which specifies the output results directory. You may wish to provide `-profile singularity` to specify the use of singularity containers and `-r [branch]` to specify which GitHub branch you would like to run. Metadata-related parameters are described above in [Input](#input).

--- a/assets/config_lookup.json
+++ b/assets/config_lookup.json
@@ -61,6 +61,7 @@
         "min_dist": { "data_type": "None", "label": "min_dist", "default": "0", "display": "True" },
         "organism": { "data_type": "None", "label": "Organism", "default": "", "display": "True" },
         "outbreak": { "data_type": "None", "label": "Outbreak Code", "default": "", "display": "True" },
+        "sample": { "data_type": "None", "label": "Sample", "default": "", "display": "True" },
         "sample_name": { "data_type": "None", "label": "Sample", "default": "", "display": "True" },
         "serovar": { "data_type": "Categorical", "label": "Serovar", "default": "", "display": "True" },
         "special": { "data_type": "Categorical", "label": "Special", "default": "", "display": "True" },

--- a/assets/config_lookup.json
+++ b/assets/config_lookup.json
@@ -2,7 +2,7 @@
     "outlier_thresh": "25",
     "min_cluster_members": 2,
     "partition_column_name": "outbreak",
-    "id_column_name": "sample",
+    "id_column_name": "sample_name",
     "only_report_labeled_columns": "False",
     "skip_qa": "False",
 
@@ -61,7 +61,7 @@
         "min_dist": { "data_type": "None", "label": "min_dist", "default": "0", "display": "True" },
         "organism": { "data_type": "None", "label": "Organism", "default": "", "display": "True" },
         "outbreak": { "data_type": "None", "label": "Outbreak Code", "default": "", "display": "True" },
-        "sample": { "data_type": "None", "label": "Sample", "default": "", "display": "True" },
+        "sample_name": { "data_type": "None", "label": "Sample", "default": "", "display": "True" },
         "serovar": { "data_type": "Categorical", "label": "Serovar", "default": "", "display": "True" },
         "special": { "data_type": "Categorical", "label": "Special", "default": "", "display": "True" },
         "source": { "data_type": "Categorical", "label": "Source Type", "default": "", "display": "True" },

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -10,9 +10,14 @@
             "sample": {
                 "type": "string",
                 "pattern": "^\\S+$",
-                "meta": ["id"],
+                "meta": ["irida_id"],
                 "unique": true,
                 "errorMessage": "Sample name must be provided and cannot contain spaces."
+            },
+            "sample_name": {
+                "type": "string",
+                "meta": ["id"],
+                "errorMessage": "Sample name is optional, if provided will replace sample for filenames and outputs"
             },
             "mlst_alleles": {
                 "type": "string",

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/phac-nml/arboratornf/main/assets/schema_input.json",
     "title": "phac-nml/arboratornf pipeline - params.input schema",
     "description": "Schema for the file provided with params.input",

--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -5,7 +5,7 @@ iridanext {
         overwrite = true
         validate = true
         files {
-            idkey = "id"
+            idkey = "irida_id"
             global = [
                 "**/arborator/cluster_summary.tsv",
                 "**/arborator/metadata.included.tsv",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ You will need to create a samplesheet with information about the samples you wou
 --input '[path to samplesheet file]'
 ```
 
-### Full samplesheet
+### Full Standard Samplesheet
 
 The input samplesheet must contain the following columns: `sample`, `mlst_alleles`, `metadata_partition`, and `metadata_1` through `metadata_8`. The IDs (sample column) within a samplesheet should be unique and contain no spaces. Any other additionally specified trailing columns will be ignored.
 
@@ -36,6 +36,29 @@ S6,S6.mlst.json,unassociated,"Escherichia coli","EAEC","Canada","O111:H21",43,"2
 | `metadata_1..metadata_8` | Metadata that will be associated with each genomic profile. These metadata will be summarized in the Arborator outputs.                                                         |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
+
+### IRIDA-Next Optional Samplesheet Configuration
+
+`arboratornf` accepts the [IRIDA-Next](https://github.com/phac-nml/irida-next) format for samplesheets which contain the following columns: `sample`, `sample_name`, `fastq_1`, `fastq_2`, `reference_assembly`, and `metadata_1` - `metadata_8`. The sample IDs within a samplesheet should be unique.
+
+A final samplesheet file consisting of both single- and paired-end data may look something like the one below.
+
+```console
+sample,sample_name,fastq_1,fastq_2,reference_assembly,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+SAMPLE1,A1,/path/to/sample1_fastq1.fq,/path/to/sample1_fastq2.fq,/path/to/sample1_assembly.fa,,,,,,,,
+SAMPLE2,B2,/path/to/sample2_fastq1.fq,,,,,,,,,,
+```
+
+| Column                       | Description                                                                                                                                                                            |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sample`                     | Custom sample name. Samples should be unique within a samplesheet.                                                                                                                     |
+| `sample_name`                | Sample name used in outputs (filenames and sample names)                                                                                                                               |
+| `fastq_1`                    | Full path to FastQ file for Illumina short reads 1. File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                                             |
+| `fastq_2`                    | (Optional) Full path to FastQ file for Illumina short reads 2. File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                                  |
+| `reference_assembly`         | (Optional) Full path to a FASTA file representing a reference assembly derived from this sample. This field provides a method for selecting a reference genome for the whole pipeline. |
+| `metadata_1` to `metadata_8` | (Optional) Permits up to 8 columns for user-defined contextual metadata associated with each `sample`.                                                                                 |
+
+An [example samplesheet](../tests/data/samplesheets/samplesheet-samplename.csv) has been provided with the pipeline.
 
 ## Running the pipeline
 

--- a/modules/local/buildconfig/main.nf
+++ b/modules/local/buildconfig/main.nf
@@ -30,7 +30,7 @@ process BUILD_CONFIG {
     def json_grouped = [:]
     def json_linelist = [:]
 
-    def id = metadata_headers[1]
+    def id = metadata_headers[0]
     def PARTITION_INDEX = 2
     def partition = metadata_headers[PARTITION_INDEX]
 

--- a/modules/local/buildconfig/main.nf
+++ b/modules/local/buildconfig/main.nf
@@ -30,8 +30,8 @@ process BUILD_CONFIG {
     def json_grouped = [:]
     def json_linelist = [:]
 
-    def id = metadata_headers[1] // Should probably not be set by column number
-    def PARTITION_INDEX = 2 // Should probably not be set by column number
+    def id = metadata_headers[1]
+    def PARTITION_INDEX = 2
     def partition = metadata_headers[PARTITION_INDEX]
 
     // GENERAL

--- a/modules/local/buildconfig/main.nf
+++ b/modules/local/buildconfig/main.nf
@@ -30,8 +30,8 @@ process BUILD_CONFIG {
     def json_grouped = [:]
     def json_linelist = [:]
 
-    def id = metadata_headers[0]
-    def PARTITION_INDEX = 1
+    def id = metadata_headers[1] // Should probably not be set by column number
+    def PARTITION_INDEX = 2 // Should probably not be set by column number
     def partition = metadata_headers[PARTITION_INDEX]
 
     // GENERAL

--- a/nextflow.config
+++ b/nextflow.config
@@ -90,7 +90,6 @@ profiles {
     }
     docker {
         docker.enabled         = true
-        docker.userEmulation   = true
         conda.enabled          = false
         singularity.enabled    = false
         podman.enabled         = false
@@ -167,6 +166,7 @@ singularity.registry = 'quay.io'
 
 // Override the default Docker registry when required
 process.ext.override_configured_container_registry = true
+process.containerOptions = '-u $(id -u):$(id -g)'
 
 // Nextflow plugins
 plugins {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/phac-nml/arboratornf/main/nextflow_schema.json",
     "title": "phac-nml/arboratornf pipeline parameters",
     "description": "IRIDA Next Example Pipeline",

--- a/tests/data/arborator/basic/metadata.included.tsv
+++ b/tests/data/arborator/basic/metadata.included.tsv
@@ -1,4 +1,4 @@
-sample	outbreak	organism	subtype	country	serovar	age	date	source	special
+sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
 S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	True
 S2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	False
 S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	True

--- a/tests/data/arborator/basic/metadata.included.tsv
+++ b/tests/data/arborator/basic/metadata.included.tsv
@@ -1,7 +1,7 @@
-sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
-S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	True
-S2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	False
-S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	True
-S4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	True
-S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	False
-S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	False
+sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special	sample
+S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	True	S1
+S2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	False	S2
+S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	True	S3
+S4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	True	S4
+S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	False	S5
+S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	False	S6

--- a/tests/data/arborator/little_metadata/metadata.included.tsv
+++ b/tests/data/arborator/little_metadata/metadata.included.tsv
@@ -1,7 +1,7 @@
-sample_name	outbreak	organism	subtype
-S1	1	Escherichia coli	EHEC/STEC
-S2	1	Escherichia coli	EHEC/STEC
-S3	2	Escherichia coli	EPEC
-S4	2	Escherichia coli	EPEC
-S5	3	Escherichia coli	EAEC
-S6	unassociated	Escherichia coli	EAEC
+sample_name	outbreak	organism	subtype	sample
+S1	1	Escherichia coli	EHEC/STEC	S1
+S2	1	Escherichia coli	EHEC/STEC	S2
+S3	2	Escherichia coli	EPEC	S3
+S4	2	Escherichia coli	EPEC	S4
+S5	3	Escherichia coli	EAEC	S5
+S6	unassociated	Escherichia coli	EAEC	S6

--- a/tests/data/arborator/little_metadata/metadata.included.tsv
+++ b/tests/data/arborator/little_metadata/metadata.included.tsv
@@ -1,4 +1,4 @@
-sample	outbreak	organism	subtype
+sample_name	outbreak	organism	subtype
 S1	1	Escherichia coli	EHEC/STEC
 S2	1	Escherichia coli	EHEC/STEC
 S3	2	Escherichia coli	EPEC

--- a/tests/data/arborator/mismatch/metadata.included.tsv
+++ b/tests/data/arborator/mismatch/metadata.included.tsv
@@ -1,7 +1,7 @@
-sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
-S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	True
-MISMATCH	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	False
-S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	True
-S4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	True
-S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	False
-S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	False
+sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special	sample
+S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	True	S1
+MISMATCH	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	False	MISMATCH
+S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	True	S3
+S4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	True	S4
+S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	False	S5
+S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	False	S6

--- a/tests/data/arborator/mismatch/metadata.included.tsv
+++ b/tests/data/arborator/mismatch/metadata.included.tsv
@@ -1,4 +1,4 @@
-sample	outbreak	organism	subtype	country	serovar	age	date	source	special
+sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
 S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	True
 MISMATCH	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	False
 S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	True

--- a/tests/data/arborator/samplenames_metadata/metadata.included.tsv
+++ b/tests/data/arborator/samplenames_metadata/metadata.included.tsv
@@ -1,7 +1,7 @@
-sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
-sample1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	True
-sample_2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	False
-sample_3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	True
-sample4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	True
-sample4_S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	False
-S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	False
+sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special	sample
+sample1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	True	S1
+sample_2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	False	S2
+sample_3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	True	S3
+sample4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	True	S4
+sample4_S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	False	S5
+S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	False	S6

--- a/tests/data/arborator/samplenames_metadata/metadata.included.tsv
+++ b/tests/data/arborator/samplenames_metadata/metadata.included.tsv
@@ -1,0 +1,7 @@
+sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
+sample1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	True
+sample_2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	False
+sample_3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	True
+sample4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	True
+sample4_S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	False
+S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	False

--- a/tests/data/configs/autoconfig_little-metadata.json
+++ b/tests/data/configs/autoconfig_little-metadata.json
@@ -2,7 +2,7 @@
     "outlier_thresh": "25",
     "min_cluster_members": 2,
     "partition_column_name": "outbreak",
-    "id_column_name": "sample",
+    "id_column_name": "sample_name",
     "only_report_labeled_columns": "False",
     "skip_qa": "False",
     "grouped_metadata_columns": {
@@ -26,7 +26,7 @@
         }
     },
     "linelist_columns": {
-        "sample": {
+        "sample_name": {
             "data_type": "None",
             "label": "Sample",
             "default": "",

--- a/tests/data/configs/autoconfig_samplesheet.json
+++ b/tests/data/configs/autoconfig_samplesheet.json
@@ -2,7 +2,7 @@
     "outlier_thresh": "25",
     "min_cluster_members": 2,
     "partition_column_name": "outbreak",
-    "id_column_name": "sample",
+    "id_column_name": "sample_name",
     "only_report_labeled_columns": "False",
     "skip_qa": "False",
     "grouped_metadata_columns": {
@@ -62,7 +62,7 @@
         }
     },
     "linelist_columns": {
-        "sample": {
+        "sample_name": {
             "data_type": "None",
             "label": "Sample",
             "default": "",

--- a/tests/data/configs/config.json
+++ b/tests/data/configs/config.json
@@ -2,11 +2,11 @@
         "outlier_thresh": "25",
         "min_cluster_members": 2,
         "partition_column_name": "outbreak",
-        "id_column_name": "sample_id",
+        "id_column_name": "sample_name",
         "only_report_labeled_columns": "False",
         "skip_qa": "False",
-        
-        "grouped_metadata_columns":{ 
+
+        "grouped_metadata_columns":{
             "outbreak":{"data_type": "None","label":"National Outbreak Code","default":"","display":"True"},
             "organism":{"data_type": "None","label":"Organism","default":"","display":"True"},
             "subtype":{"data_type": "None","label":"Subtype","default":"","display":"True"},
@@ -19,7 +19,7 @@
         },
 
         "linelist_columns":{
-            "sample":{"data_type": "None","label":"Sample","default":"","display":"True"},
+            "sample_name":{"data_type": "None","label":"Sample","default":"","display":"True"},
             "outbreak":{"data_type": "None","label":"National Outbreak Code","default":"","display":"True"},
             "organism":{"data_type": "None","label":"Organism","default":"","display":"True"},
             "subtype":{"data_type": "None","label":"Subtype","default":"","display":"True"},
@@ -29,5 +29,5 @@
             "date":{"data_type": "min_max","label":"Date","default":"","display":"True"},
             "source":{"data_type": "categorical","label":"Source Type","default":"","display":"True"},
             "special":{"data_type": "categorical","label":"Special","default":"","display":"True"}
-        }    
+        }
     }

--- a/tests/data/metadata/expected_merged_data.tsv
+++ b/tests/data/metadata/expected_merged_data.tsv
@@ -1,7 +1,7 @@
-sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
-S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
-S2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
-S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true
-S4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	true
-S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	false
-S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	false
+sample	sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
+S1	S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
+S2	S2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
+S3	S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true
+S4	S4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	true
+S5	S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	false
+S6	S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	false

--- a/tests/data/metadata/expected_merged_data.tsv
+++ b/tests/data/metadata/expected_merged_data.tsv
@@ -1,4 +1,4 @@
-sample	outbreak	organism	subtype	country	serovar	age	date	source	special
+sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
 S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
 S2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
 S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true

--- a/tests/data/metadata/expected_merged_data.tsv
+++ b/tests/data/metadata/expected_merged_data.tsv
@@ -1,4 +1,4 @@
-sample	sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
+sample_name	sample	outbreak	organism	subtype	country	serovar	age	date	source	special
 S1	S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
 S2	S2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
 S3	S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true

--- a/tests/data/metadata/little-metadata-merged.tsv
+++ b/tests/data/metadata/little-metadata-merged.tsv
@@ -1,7 +1,7 @@
-sample_name	outbreak	organism	subtype
-S1	1	Escherichia coli	EHEC/STEC
-S2	1	Escherichia coli	EHEC/STEC
-S3	2	Escherichia coli	EPEC
-S4	2	Escherichia coli	EPEC
-S5	3	Escherichia coli	EAEC
-S6	unassociated	Escherichia coli	EAEC
+sample	sample_name	outbreak	organism	subtype
+S1	S1	1	Escherichia coli	EHEC/STEC
+S2	S2	1	Escherichia coli	EHEC/STEC
+S3	S3	2	Escherichia coli	EPEC
+S4	S4	2	Escherichia coli	EPEC
+S5	S5	3	Escherichia coli	EAEC
+S6	S6	unassociated	Escherichia coli	EAEC

--- a/tests/data/metadata/little-metadata-merged.tsv
+++ b/tests/data/metadata/little-metadata-merged.tsv
@@ -1,4 +1,4 @@
-sample	outbreak	organism	subtype
+sample_name	outbreak	organism	subtype
 S1	1	Escherichia coli	EHEC/STEC
 S2	1	Escherichia coli	EHEC/STEC
 S3	2	Escherichia coli	EPEC

--- a/tests/data/metadata/little-metadata-merged.tsv
+++ b/tests/data/metadata/little-metadata-merged.tsv
@@ -1,4 +1,4 @@
-sample	sample_name	outbreak	organism	subtype
+sample_name	sample	outbreak	organism	subtype
 S1	S1	1	Escherichia coli	EHEC/STEC
 S2	S2	1	Escherichia coli	EHEC/STEC
 S3	S3	2	Escherichia coli	EPEC

--- a/tests/data/metadata/mismatched-metadata.tsv
+++ b/tests/data/metadata/mismatched-metadata.tsv
@@ -1,4 +1,4 @@
-sample	outbreak	organism	subtype	country	serovar	age	date	source	special
+sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
 S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
 MISMATCH	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
 S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true

--- a/tests/data/metadata/mismatched-metadata.tsv
+++ b/tests/data/metadata/mismatched-metadata.tsv
@@ -1,7 +1,7 @@
-sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
-S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
-MISMATCH	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
-S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true
-S4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	true
-S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	false
-S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	false
+sample	sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
+S1	S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
+MISMATCH	MISMATCH	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
+S3	S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true
+S4	S4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	true
+S5	S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	false
+S6	S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	false

--- a/tests/data/metadata/mismatched-metadata.tsv
+++ b/tests/data/metadata/mismatched-metadata.tsv
@@ -1,4 +1,4 @@
-sample	sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
+sample_name	sample	outbreak	organism	subtype	country	serovar	age	date	source	special
 S1	S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
 MISMATCH	MISMATCH	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
 S3	S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true

--- a/tests/data/metadata/samplenames-merged.tsv
+++ b/tests/data/metadata/samplenames-merged.tsv
@@ -1,7 +1,7 @@
-sample	sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
-S1	sample1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
-S2	sample_2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
-S3	sample_3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true
-S4	sample4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	true
-S5	sample4_S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	false
+sample_name	sample	outbreak	organism	subtype	country	serovar	age	date	source	special
+sample1	S1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
+sample_2	S2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
+sample_3	S3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true
+sample4	S4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	true
+sample4_S5	S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	false
 S6	S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	false

--- a/tests/data/metadata/samplenames-merged.tsv
+++ b/tests/data/metadata/samplenames-merged.tsv
@@ -1,0 +1,7 @@
+sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
+sample1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
+sample_2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
+sample_3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true
+sample4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	true
+sample4_S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	false
+S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	false

--- a/tests/data/metadata/samplenames-merged.tsv
+++ b/tests/data/metadata/samplenames-merged.tsv
@@ -1,7 +1,7 @@
-sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
-sample1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
-sample_2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
-sample_3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true
-sample4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	true
-sample4_S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	false
-S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	false
+sample	sample_name	outbreak	organism	subtype	country	serovar	age	date	source	special
+S1	sample1	1	Escherichia coli	EHEC/STEC	Canada	O157:H7	21	2024/05/30	beef	true
+S2	sample_2	1	Escherichia coli	EHEC/STEC	The United States	O157:H7	55	2024/05/21	milk	false
+S3	sample_3	2	Escherichia coli	EPEC	France	O125	14	2024/04/30	cheese	true
+S4	sample4	2	Escherichia coli	EPEC	France	O125	35	2024/04/22	cheese	true
+S5	sample4_S5	3	Escherichia coli	EAEC	Canada	O126:H27	61	2012/09/01	milk	false
+S6	S6	unassociated	Escherichia coli	EAEC	Canada	O111:H21	43	2011/12/25	fruit	false

--- a/tests/data/profiles/samplenames_profiles.tsv
+++ b/tests/data/profiles/samplenames_profiles.tsv
@@ -1,0 +1,7 @@
+sample_id	locus_1	locus_2	locus_3	locus_4	locus_5	locus_6	locus_7
+sample1	1	1	1	1	1	1	1
+sample_2	1	1	2	2	?	4	1
+sample_3	1	2	2	2	1	5	1
+sample4	1	2	3	2	1	6	1
+sample4_S5	1	2	?	2	1	8	1
+S6	2	3	3	-	?	9	0

--- a/tests/data/samplesheets/samplesheet-samplename.csv
+++ b/tests/data/samplesheets/samplesheet-samplename.csv
@@ -1,0 +1,7 @@
+sample,sample_name,mlst_alleles,metadata_partition,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+S1,sample1,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S1.mlst.json,1,"Escherichia coli","EHEC/STEC","Canada","O157:H7",21,"2024/05/30","beef",true
+S2,sample 2,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S2.mlst.json,1,"Escherichia coli","EHEC/STEC","The United States","O157:H7",55,"2024/05/21","milk",false
+S3,sample#3,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S3.mlst.json,2,"Escherichia coli","EPEC","France","O125",14,"2024/04/30","cheese",true
+S4,sample4,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S4.mlst.json,2,"Escherichia coli","EPEC","France","O125",35,"2024/04/22","cheese",true
+S5,sample4,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S5.mlst.json,3,"Escherichia coli","EAEC","Canada","O126:H27",61,"2012/09/01","milk",false
+S6,,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S6.mlst.json,unassociated,"Escherichia coli","EAEC","Canada","O111:H21",43,"2011/12/25","fruit",false

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -70,13 +70,13 @@ nextflow_pipeline {
             assert path("$launchDir/results/arborator/2_tree.nwk").exists()
 
             // Check that the ArborView output is created
-            def actual_arborview = path("$launchDir/results/arborview/1_arborview.html")
-            assert actual_arborview.exists()
-            assert actual_arborview.text.contains("sample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nS2\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
+            def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
+            assert actual_arborview1.exists()
+            assert actual_arborview1.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nS2\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
 
-            actual_arborview = path("$launchDir/results/arborview/2_arborview.html")
-            assert actual_arborview.exists()
-            assert actual_arborview.text.contains("sample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
+            def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
+            assert actual_arborview2.exists()
+            assert actual_arborview2.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -177,13 +177,13 @@ nextflow_pipeline {
             assert path("$launchDir/results/arborator/2_tree.nwk").exists()
 
             // Check that the ArborView output is created
-            def actual_arborview = path("$launchDir/results/arborview/1_arborview.html")
-            assert actual_arborview.exists()
-            assert actual_arborview.text.contains("sample\\toutbreak\\torganism\\tsubtype\\nS1\\t1\\tEscherichia coli\\tEHEC/STEC\\nS2\\t1\\tEscherichia coli\\tEHEC/STEC\\n")
+            def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
+            assert actual_arborview1.exists()
+            assert actual_arborview1.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\nS1\\t1\\tEscherichia coli\\tEHEC/STEC\\nS2\\t1\\tEscherichia coli\\tEHEC/STEC\\n")
 
-            actual_arborview = path("$launchDir/results/arborview/2_arborview.html")
-            assert actual_arborview.exists()
-            assert actual_arborview.text.contains("sample\\toutbreak\\torganism\\tsubtype\\nS3\\t2\\tEscherichia coli\\tEPEC\\nS4\\t2\\tEscherichia coli\\tEPEC\\n")
+            def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
+            assert actual_arborview2.exists()
+            assert actual_arborview2.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\nS3\\t2\\tEscherichia coli\\tEPEC\\nS4\\t2\\tEscherichia coli\\tEPEC\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -435,13 +435,13 @@ nextflow_pipeline {
             assert path("$launchDir/results/arborator/2_tree.nwk").exists()
 
             // Check that the ArborView output is created
-            def actual_arborview = path("$launchDir/results/arborview/1_arborview.html")
-            assert actual_arborview.exists()
-            assert actual_arborview.text.contains("sample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nMISMATCH\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
+            def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
+            assert actual_arborview1.exists()
+            assert actual_arborview1.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nMISMATCH\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
 
-            actual_arborview = path("$launchDir/results/arborview/2_arborview.html")
-            assert actual_arborview.exists()
-            assert actual_arborview.text.contains("sample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
+            def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
+            assert actual_arborview2.exists()
+            assert actual_arborview2.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -72,11 +72,11 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
             assert actual_arborview1.exists()
-            assert actual_arborview1.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\tS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nS2\\tS2\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
+            assert actual_arborview1.text.contains("sample_name\\tsample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\tS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nS2\\tS2\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
 
             def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
             assert actual_arborview2.exists()
-            assert actual_arborview2.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\tS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\tS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
+            assert actual_arborview2.text.contains("sample_name\\tsample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\tS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\tS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -179,11 +179,11 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
             assert actual_arborview1.exists()
-            assert actual_arborview1.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\nS1\\tS1\\t1\\tEscherichia coli\\tEHEC/STEC\\nS2\\tS2\\t1\\tEscherichia coli\\tEHEC/STEC\\n")
+            assert actual_arborview1.text.contains("sample_name\\tsample\\toutbreak\\torganism\\tsubtype\\nS1\\tS1\\t1\\tEscherichia coli\\tEHEC/STEC\\nS2\\tS2\\t1\\tEscherichia coli\\tEHEC/STEC\\n")
 
             def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
             assert actual_arborview2.exists()
-            assert actual_arborview2.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\nS3\\tS3\\t2\\tEscherichia coli\\tEPEC\\nS4\\tS4\\t2\\tEscherichia coli\\tEPEC\\n")
+            assert actual_arborview2.text.contains("sample_name\\tsample\\toutbreak\\torganism\\tsubtype\\nS3\\tS3\\t2\\tEscherichia coli\\tEPEC\\nS4\\tS4\\t2\\tEscherichia coli\\tEPEC\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -437,11 +437,11 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
             assert actual_arborview1.exists()
-            assert actual_arborview1.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\tS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nMISMATCH\\tMISMATCH\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
+            assert actual_arborview1.text.contains("sample_name\\tsample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\tS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nMISMATCH\\tMISMATCH\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
 
             def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
             assert actual_arborview2.exists()
-            assert actual_arborview2.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\tS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\tS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
+            assert actual_arborview2.text.contains("sample_name\\tsample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\tS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\tS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -544,11 +544,11 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
             assert actual_arborview1.exists()
-            assert actual_arborview1.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\tsample1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nS2\\tsample_2\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
+            assert actual_arborview1.text.contains("sample_name\\tsample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nsample1\\tS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nsample_2\\tS2\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
 
             def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
             assert actual_arborview2.exists()
-            assert actual_arborview2.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\tsample_3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\tsample4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
+            assert actual_arborview2.text.contains("sample_name\\tsample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nsample_3\\tS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nsample4\\tS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -473,4 +473,111 @@ nextflow_pipeline {
             assert iridanext_metadata.isEmpty()
         }
     }
+
+    test("Small-scale test of full pipeline, sample_name column added"){
+        tag "sample_name"
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-samplename.csv"
+                outdir = "results"
+
+                metadata_partition_name = "outbreak"
+                metadata_1_header = "organism"
+                metadata_2_header = "subtype"
+                metadata_3_header = "country"
+                metadata_4_header = "serovar"
+                metadata_5_header = "age"
+                metadata_6_header = "date"
+                metadata_7_header = "source"
+                metadata_8_header = "special"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check merged profiles
+            def actual_profile_tsv = path("$launchDir/results/merged/profile.tsv")
+            def expected_profile_tsv = path("$baseDir/tests/data/profiles/samplenames_profiles.tsv")
+            assert actual_profile_tsv.text == expected_profile_tsv.text
+
+            // Check aggregated metadata
+            def actual_metadata = path("$launchDir/results/metadata/aggregated_data.tsv")
+            def expected_metadata = path("$baseDir/tests/data/metadata/samplenames-merged.tsv")
+            assert actual_metadata.text == expected_metadata.text
+
+            // Check auto-built config file:
+            def actual_config = path("$launchDir/results/build/config.json")
+            def expected_config = path("$baseDir/tests/data/configs/autoconfig_samplesheet.json")
+            assert actual_config.text == expected_config.text
+
+            // Arborator outputs:
+            // NOTE: Arborator produces a (somewhat) non-deterministic cluster summary,
+            // so it's not possible to compare the entire output.
+            def actual_arborator_summary = path("$launchDir/results/arborator/cluster_summary.tsv")
+            assert actual_arborator_summary.text.contains("Outbreak Code\tOrganism\tSubtype")
+            assert actual_arborator_summary.text.contains("1\tEscherichia coli\tEHEC/STEC")
+
+            def actual_arborator_meta_included = path("$launchDir/results/arborator/metadata.included.tsv")
+            def expected_arborator_meta_included = path("$baseDir/tests/data/arborator/samplenames_metadata/metadata.included.tsv")
+            assert actual_arborator_meta_included.text == expected_arborator_meta_included.text
+
+            assert path("$launchDir/results/arborator/1_clusters.tsv").exists()
+            assert path("$launchDir/results/arborator/1_loci.summary.tsv").exists()
+            assert path("$launchDir/results/arborator/1_matrix.pq").exists()
+            assert path("$launchDir/results/arborator/1_matrix.tsv").exists()
+            assert path("$launchDir/results/arborator/1_metadata.tsv").exists()
+            assert path("$launchDir/results/arborator/1_outliers.tsv").exists()
+            assert path("$launchDir/results/arborator/1_profile.tsv").exists()
+            assert path("$launchDir/results/arborator/1_tree.nwk").exists()
+
+            assert path("$launchDir/results/arborator/2_clusters.tsv").exists()
+            assert path("$launchDir/results/arborator/2_loci.summary.tsv").exists()
+            assert path("$launchDir/results/arborator/2_matrix.pq").exists()
+            assert path("$launchDir/results/arborator/2_matrix.tsv").exists()
+            assert path("$launchDir/results/arborator/2_metadata.tsv").exists()
+            assert path("$launchDir/results/arborator/2_outliers.tsv").exists()
+            assert path("$launchDir/results/arborator/2_profile.tsv").exists()
+            assert path("$launchDir/results/arborator/2_tree.nwk").exists()
+
+            // Check that the ArborView output is created
+            def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
+            assert actual_arborview1.exists()
+            assert actual_arborview1.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nsample1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nsample_2\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
+
+            def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
+            assert actual_arborview2.exists()
+            assert actual_arborview2.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nsample_3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nsample4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
+
+            // compare IRIDA Next JSON output
+            def iridanext_json = path("$launchDir/results/iridanext.output.json").json
+            def iridanext_global = iridanext_json.files.global
+            def iridanext_samples = iridanext_json.files.samples
+            def iridanext_metadata = iridanext_json.metadata.samples
+
+            assert iridanext_global.findAll { it.path == "arborator/1_clusters.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_loci.summary.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_matrix.pq" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_matrix.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_metadata.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_outliers.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_profile.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/1_tree.nwk" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_clusters.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_loci.summary.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_matrix.pq" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_matrix.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_metadata.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_outliers.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_profile.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/2_tree.nwk" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/cluster_summary.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/metadata.excluded.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "arborator/metadata.included.tsv" }.size() == 1
+
+            assert iridanext_samples.isEmpty()
+            assert iridanext_metadata.isEmpty()
+        }
+    }
 }

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -72,11 +72,11 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
             assert actual_arborview1.exists()
-            assert actual_arborview1.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nS2\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
+            assert actual_arborview1.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\tS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nS2\\tS2\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
 
             def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
             assert actual_arborview2.exists()
-            assert actual_arborview2.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
+            assert actual_arborview2.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\tS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\tS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -179,11 +179,11 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
             assert actual_arborview1.exists()
-            assert actual_arborview1.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\nS1\\t1\\tEscherichia coli\\tEHEC/STEC\\nS2\\t1\\tEscherichia coli\\tEHEC/STEC\\n")
+            assert actual_arborview1.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\nS1\\tS1\\t1\\tEscherichia coli\\tEHEC/STEC\\nS2\\tS2\\t1\\tEscherichia coli\\tEHEC/STEC\\n")
 
             def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
             assert actual_arborview2.exists()
-            assert actual_arborview2.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\nS3\\t2\\tEscherichia coli\\tEPEC\\nS4\\t2\\tEscherichia coli\\tEPEC\\n")
+            assert actual_arborview2.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\nS3\\tS3\\t2\\tEscherichia coli\\tEPEC\\nS4\\tS4\\t2\\tEscherichia coli\\tEPEC\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -437,11 +437,11 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
             assert actual_arborview1.exists()
-            assert actual_arborview1.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nMISMATCH\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
+            assert actual_arborview1.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\tS1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nMISMATCH\\tMISMATCH\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
 
             def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
             assert actual_arborview2.exists()
-            assert actual_arborview2.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
+            assert actual_arborview2.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\tS3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\tS4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -544,11 +544,11 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview1 = path("$launchDir/results/arborview/1_arborview.html")
             assert actual_arborview1.exists()
-            assert actual_arborview1.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nsample1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nsample_2\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
+            assert actual_arborview1.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\tsample1\\t1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nS2\\tsample_2\\t1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
 
             def actual_arborview2 = path("$launchDir/results/arborview/2_arborview.html")
             assert actual_arborview2.exists()
-            assert actual_arborview2.text.contains("sample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nsample_3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nsample4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
+            assert actual_arborview2.text.contains("sample\\tsample_name\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\tsample_3\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\tsample4\\t2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json

--- a/workflows/cluster_splitter.nf
+++ b/workflows/cluster_splitter.nf
@@ -77,7 +77,7 @@ workflow CLUSTER_SPLITTER {
     // Metadata headers:
     metadata_headers = Channel.value(
         tuple(
-            ID_COLUMN2, ID_COLUMN, params.metadata_partition_name,
+            ID_COLUMN, ID_COLUMN2, params.metadata_partition_name,
             params.metadata_1_header, params.metadata_2_header,
             params.metadata_3_header, params.metadata_4_header,
             params.metadata_5_header, params.metadata_6_header,
@@ -86,7 +86,7 @@ workflow CLUSTER_SPLITTER {
 
     // Metadata rows:
     metadata_rows = input_assure.result.map{
-        meta, mlst_files -> tuple(meta.irida_id, meta.id, meta.metadata_partition,
+        meta, mlst_files -> tuple(meta.id, meta.irida_id, meta.metadata_partition,
         meta.metadata_1, meta.metadata_2, meta.metadata_3, meta.metadata_4,
         meta.metadata_5, meta.metadata_6, meta.metadata_7, meta.metadata_8)
     }.toList()

--- a/workflows/cluster_splitter.nf
+++ b/workflows/cluster_splitter.nf
@@ -44,6 +44,7 @@ include { CUSTOM_DUMPSOFTWAREVERSIONS } from '../modules/nf-core/custom/dumpsoft
 workflow CLUSTER_SPLITTER {
 
     ID_COLUMN = "sample_name"
+    ID_COLUMN2 = "sample"
     ch_versions = Channel.empty()
 
     // Track processed IDs
@@ -76,7 +77,7 @@ workflow CLUSTER_SPLITTER {
     // Metadata headers:
     metadata_headers = Channel.value(
         tuple(
-            ID_COLUMN, params.metadata_partition_name,
+            ID_COLUMN2, ID_COLUMN, params.metadata_partition_name,
             params.metadata_1_header, params.metadata_2_header,
             params.metadata_3_header, params.metadata_4_header,
             params.metadata_5_header, params.metadata_6_header,
@@ -85,7 +86,7 @@ workflow CLUSTER_SPLITTER {
 
     // Metadata rows:
     metadata_rows = input_assure.result.map{
-        meta, mlst_files -> tuple(meta.id, meta.metadata_partition,
+        meta, mlst_files -> tuple(meta.irida_id, meta.id, meta.metadata_partition,
         meta.metadata_1, meta.metadata_2, meta.metadata_3, meta.metadata_4,
         meta.metadata_5, meta.metadata_6, meta.metadata_7, meta.metadata_8)
     }.toList()


### PR DESCRIPTION
Modified the template for input `samplesheet.csv` file to include the `sample_name` column in addition to `sample` in-line with changes to [IRIDA-Next update] as seen with the [speciesabundance pipeline] and [staramrnf]. What this means is that the output files and the `sample` name will be changed to `sample_name` if a `sample_name` is called. If `arborator` is being locally then the `sample_name` can be left blank.

Made a few changes:
    - `sample_name` special characters will be replaced with `"_"`
    - If no `sample_name` is supplied in the column `sample` will be used
    - To avoid repeat values for `sample_name` all `sample_name` values will be suffixed with `sample`
    - Tests to check that the variety of different `sample_names` work with the 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Add `nf-test` to test new feature
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
- [x] Tested out in IRIDA-Next locally

[IRIDA-Next update]: https://github.com/phac-nml/irida-next/pull/678
[speciesabundance pipeline]: https://github.com/phac-nml/speciesabundance/pull/24
[staramrnf]: https://github.com/phac-nml/staramrnf/pull/28
