### PR TITLE
Update Fix `docker.userEmulation` Removal

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.7.1"
+    rev: "v3.2.5"
     hooks:
       - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.2.5"
+    rev: "v3.0.0"
     hooks:
       - id: prettier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Development
+## [0.3.1] - 2024-10-31
 
 - Fixed the replacement of `docker.userEmulation` with `docker.runOptions      = '-u $(id -u):$(id -g)'` that was causing a bug in Azure
 
@@ -40,3 +40,4 @@ Initial release of the arboratornf pipeline to be used for running [Arborator](h
 [0.1.0]: https://github.com/phac-nml/arboratornf/releases/tag/0.1.0
 [0.2.0]: https://github.com/phac-nml/arboratornf/releases/tag/0.2.0
 [0.3.0]: https://github.com/phac-nml/arboratornf/releases/tag/0.3.0
+[0.3.1]: https://github.com/phac-nml/arboratornf/releases/tag/0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] - 2024-10-31
+## [0.3.1] - 2024-11-05
 
 - Fixed the replacement of `docker.userEmulation` with `docker.runOptions      = '-u $(id -u):$(id -g)'` that was causing a bug in Azure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Development
+
+- Fixed the replacement of `docker.userEmulation` with `docker.runOptions      = '-u $(id -u):$(id -g)'` that was causing a bug in Azure
+
 ## [0.3.0] - 2024-10-21
 
 - Added the ability to include a `sample_name` column in the input samplesheet.csv. Allows for compatibility with IRIDA-Next input configuration.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,24 +39,25 @@ An [example samplesheet](../assets/samplesheet.csv) has been provided with the p
 
 ### IRIDA-Next Optional Samplesheet Configuration
 
-`arboratornf` accepts the [IRIDA-Next](https://github.com/phac-nml/irida-next) format for samplesheets which contain the following columns: `sample`, `sample_name`, `fastq_1`, `fastq_2`, `reference_assembly`, and `metadata_1` - `metadata_8`. The sample IDs within a samplesheet should be unique.
-
-A final samplesheet file consisting of both single- and paired-end data may look something like the one below.
+`arboratornf` accepts the [IRIDA-Next](https://github.com/phac-nml/irida-next) format for samplesheets which contain the following columns: `sample`, `sample_name`, `mlst_alleles`, `metadata_partition`, and `metadata_1` through `metadata_8`. The IDs (sample column) within a samplesheet should be unique and contain no spaces. Any other additionally specified trailing columns will be ignored.
 
 ```console
-sample,sample_name,fastq_1,fastq_2,reference_assembly,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
-SAMPLE1,A1,/path/to/sample1_fastq1.fq,/path/to/sample1_fastq2.fq,/path/to/sample1_assembly.fa,,,,,,,,
-SAMPLE2,B2,/path/to/sample2_fastq1.fq,,,,,,,,,,
+sample,sample_name,mlst_alleles,metadata_partition,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+S1,sample1,S1.mlst.json,1,"Escherichia coli","EHEC/STEC","Canada","O157:H7",21,"2024/05/30","beef",true
+S2,sample2,S2.mlst.json,1,"Escherichia coli","EHEC/STEC","The United States","O157:H7",55,"2024/05/21","milk",false
+S3,sampleQ,S3.mlst.json,2,"Escherichia coli","EPEC","France","O125",14,"2024/04/30","cheese",true
+S4,sampleQ,S4.mlst.json,2,"Escherichia coli","EPEC","France","O125",35,"2024/04/22","cheese",true
+S5,sample#5,S5.mlst.json,3,"Escherichia coli","EAEC","Canada","O126:H27",61,"2012/09/01","milk",false
+S6,,S6.mlst.json,unassociated,"Escherichia coli","EAEC","Canada","O111:H21",43,"2011/12/25","fruit",false
 ```
 
-| Column                       | Description                                                                                                                                                                            |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sample`                     | Custom sample name. Samples should be unique within a samplesheet.                                                                                                                     |
-| `sample_name`                | Sample name used in outputs (filenames and sample names)                                                                                                                               |
-| `fastq_1`                    | Full path to FastQ file for Illumina short reads 1. File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                                             |
-| `fastq_2`                    | (Optional) Full path to FastQ file for Illumina short reads 2. File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                                  |
-| `reference_assembly`         | (Optional) Full path to a FASTA file representing a reference assembly derived from this sample. This field provides a method for selecting a reference genome for the whole pipeline. |
-| `metadata_1` to `metadata_8` | (Optional) Permits up to 8 columns for user-defined contextual metadata associated with each `sample`.                                                                                 |
+| Column                   | Description                                                                                                                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sample`                 | Custom sample name. Samples should be unique within a samplesheet.                                                                                                              |
+| `sample_name`            | Sample name used in outputs (filenames and sample names)                                                                                                                        |
+| `mlst_alleles`           | A URI path to a JSON-formatted genomic profile. An example of this file is provided in [tests/data/profiles/S1.mlst.json](../tests/data/profiles/S1.mlst.json).                 |
+| `metadata_partition`     | The specific metadata column used to partition the genomic profiles. For example, this column might refer to the outbreak number and the contain such entries as "1", "2", etc. |
+| `metadata_1..metadata_8` | Metadata that will be associated with each genomic profile. These metadata will be summarized in the Arborator outputs.                                                         |
 
 An [example samplesheet](../tests/data/samplesheets/samplesheet-samplename.csv) has been provided with the pipeline.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -90,7 +90,7 @@ profiles {
     }
     docker {
         docker.enabled         = true
-        docker.userEmulation   = true
+        docker.runOptions      = '-u $(id -u):$(id -g)'
         conda.enabled          = false
         singularity.enabled    = false
         podman.enabled         = false
@@ -167,6 +167,7 @@ singularity.registry = 'quay.io'
 
 // Override the default Docker registry when required
 process.ext.override_configured_container_registry = true
+
 
 // Nextflow plugins
 plugins {

--- a/nextflow.config
+++ b/nextflow.config
@@ -90,6 +90,7 @@ profiles {
     }
     docker {
         docker.enabled         = true
+        docker.userEmulation   = true
         conda.enabled          = false
         singularity.enabled    = false
         podman.enabled         = false
@@ -166,7 +167,6 @@ singularity.registry = 'quay.io'
 
 // Override the default Docker registry when required
 process.ext.override_configured_container_registry = true
-process.containerOptions = '-u $(id -u):$(id -g)'
 
 // Nextflow plugins
 plugins {

--- a/nextflow.config
+++ b/nextflow.config
@@ -214,7 +214,7 @@ manifest {
     description     = """Arborator: Genomic Profile Clustering and Summary"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.3.0'
+    version         = '0.3.1'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
The setting in the docker profile `docker.userEmulation` was removed from Nextflow in this [PR 4596](https://github.com/nextflow-io/nextflow/pull/4596). 

Following this [issue](https://github.com/nextflow-io/nextflow/issues/4600) I had implemented this at the process level as in this [PR](https://github.com/phac-nml/arboratornf/pull/23)
```
process.containerOptions = '-u $(id -u):$(id -g)'
```

This caused problems when running on Azure but not locally, and was missed in tests.

However the correct solution, as seen in the nf-core template, [here](https://github.com/nf-core/tools/blob/b51c7d85e1eb29e49360d9712374cd5a95f9c6cc/nf_core/pipeline-template/nextflow.config#L123) is to put it in the docker profile as via `docker.runOptions      = '-u $(id -u):$(id -g)'`
e.g,

```
docker {
        docker.enabled         = true
        conda.enabled          = false
        singularity.enabled    = false
        podman.enabled         = false
        shifter.enabled        = false
        charliecloud.enabled   = false
        apptainer.enabled      = false
        docker.runOptions      = '-u $(id -u):$(id -g)'
    }
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Test in IRIDA-Next
- [x] Test on Azure
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
