### PR TITLE
Updated aborator container which contains GAS 0.1.4

### DIFF
--- a/modules/local/arborator/main.nf
+++ b/modules/local/arborator/main.nf
@@ -8,8 +8,8 @@ process ARBORATOR {
     label 'process_high'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/arborator%3A1.0.0--pyhdfd78af_2' :
-    'biocontainers/arborator:1.0.0--pyhdfd78af_2' }"
+    'https://depot.galaxyproject.org/singularity/arborator%3A1.0.0--pyhdfd78af_3' :
+    'biocontainers/arborator:1.0.0--pyhdfd78af_3' }"
 
     input:
     path merged_profiles // The allelic profiles


### PR DESCRIPTION
A very simple change, which is a change to arborator container -- which now has GAS 0.1.4.
Doesn't have any impact on `aboratornf`.

```
docker run -it quay.io/biocontainers/arborator:1.0.0--pyhdfd78af_2 gas call --version
gas 0.1.4
```
