### PR TITLE
Update/profile dists via arborator build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Updated`
 
 - Update the `ArborView` version to [0.0.8](https://github.com/phac-nml/ArborView/releases/tag/v0.0.8) (i.e. replace `bin/inline_arborview.py` with `scripts/fillin_data.py` and `assets/ArborView.html` with `html/table.html`) [PR #33](https://github.com/phac-nml/arboratornf/pull/33)
+- Update the `aborator` container [build](https://github.com/bioconda/bioconda-recipes/pull/55278) which in turn updates the dependency, `profile_dists`, to version 1.0.4 [PR #36](https://github.com/phac-nml/arboratornf/pull/36)
 
 ### `Changed`
 

--- a/modules/local/arborator/main.nf
+++ b/modules/local/arborator/main.nf
@@ -8,8 +8,8 @@ process ARBORATOR {
     label 'process_high'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/arborator%3A1.0.0--pyhdfd78af_4' :
-    'biocontainers/arborator:1.0.0--pyhdfd78af_4' }"
+    'https://depot.galaxyproject.org/singularity/arborator%3A1.0.0--pyhdfd78af_5' :
+    'biocontainers/arborator:1.0.0--pyhdfd78af_5' }"
 
     input:
     path merged_profiles // The allelic profiles


### PR DESCRIPTION
## STRY0017582: Update `profile_dists` to 1.0.4

## Description

As a data analyst, I would like `profile_dists` updated to `1.0.4` in arboratornf so that distance calculations in the pipeline are fixed. `profile_dists` is not used directly called in a process but is a [dependency](https://github.com/phac-nml/arborator/blob/c4abe07d0aaf5f186090b6461888d7060aa2deff/README.md?plain=1#L76) of `arborator` and so the [build](https://github.com/bioconda/bioconda-recipes/pull/55278) of arborator 1.0.0 contains `profile_dists : 1.0.4`.

## Checklist

- [x] Update profile_dists to 1.0.4 in arboratornf
- [x] Update tests to confirm fix is working.

<!--
# phac-nml/arboratornf pull request

Many thanks for contributing to phac-nml/arboratornf!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/phac-nml/arboratornf/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
