### PR TITLE
Fixes #38 Arborview Shortens Outputfile name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           sudo mv nf-test /usr/local/bin/
 
       - name: Run nf-test
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
           nf-test test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,5 +56,6 @@ jobs:
           nf-test test
 
       - name: Nextflow run with test profile
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2025-05-dd
+
+### `Fix`
+
+- Fixes the issue [#38](https://github.com/phac-nml/arboratornf/issues/38) `metadata_partition` containing a "." where leading to misnamed Arborview output files. [PR #38](https://github.com/phac-nml/arboratornf/pull/38)
+
 ## [0.3.5] - 2025-04-16
 
 ### `Updated`
@@ -72,3 +78,4 @@ Initial release of the arboratornf pipeline to be used for running [Arborator](h
 [0.3.3]: https://github.com/phac-nml/arboratornf/releases/tag/0.3.3
 [0.3.4]: https://github.com/phac-nml/arboratornf/releases/tag/0.3.4
 [0.3.5]: https://github.com/phac-nml/arboratornf/releases/tag/0.3.5
+[0.3.6]: https://github.com/phac-nml/arboratornf/releases/tag/0.3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fix`
 
-- Fixes the issue [#38](https://github.com/phac-nml/arboratornf/issues/38) `metadata_partition` containing a "." where leading to misnamed Arborview output files. [PR #38](https://github.com/phac-nml/arboratornf/pull/38)
+- Fixes the issue [#38](https://github.com/phac-nml/arboratornf/issues/38) `metadata_partition` containing a "." were leading to misnamed Arborview output files. [PR #38](https://github.com/phac-nml/arboratornf/pull/38)
+
+### `Added`
+
+- `/pipeline_info/software_versions.yml` now added to the global files in the `iridanext.output.json.gz` to allow IRIDA-Next users access to software versions. [PR #38](https://github.com/phac-nml/arboratornf/pull/38)
 
 ## [0.3.5] - 2025-04-16
 

--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -18,7 +18,8 @@ iridanext {
                 "**/arborator/*_matrix.tsv",
                 "**/arborator/*_outliers.tsv",
                 "**/arborator/*_clusters.tsv",
-                "**/arborview/*_arborview.html"
+                "**/arborview/*_arborview.html",
+                "**/pipeline_info/software_versions.yml"
             ]
         }
     }

--- a/tests/data/samplesheets/samplesheet-filename-fix.csv
+++ b/tests/data/samplesheets/samplesheet-filename-fix.csv
@@ -1,0 +1,7 @@
+sample,mlst_alleles,metadata_partition,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+S1,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S1.mlst.json,1.1.1.1,"Escherichia coli","EHEC/STEC","Canada","O157:H7",21,"2024/05/30","beef",true
+S2,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S2.mlst.json,1.1.1.1,"Escherichia coli","EHEC/STEC","The United States","O157:H7",55,"2024/05/21","milk",false
+S3,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S3.mlst.json,1.1.1.2,"Escherichia coli","EPEC","France","O125",14,"2024/04/30","cheese",true
+S4,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S4.mlst.json,1.1.1.2,"Escherichia coli","EPEC","France","O125",35,"2024/04/22","cheese",true
+S5,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S5.mlst.json,1.1.1.3,"Escherichia coli","EAEC","Canada","O126:H27",61,"2012/09/01","milk",false
+S6,https://raw.githubusercontent.com/phac-nml/arboratornf/dev/tests/data/profiles/S6.mlst.json,unassociated,"Escherichia coli","EAEC","Canada","O111:H21",43,"2011/12/25","fruit",false

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -676,4 +676,42 @@ nextflow_pipeline {
             assert iridanext_metadata.isEmpty()
         }
     }
+
+    test("Arborview output filename (includes full genomic address name)"){
+        tag "arborview_filename"
+        // This test checks that the ArborView output filename includes the full genomic address name.
+        // It is included in the pipelines not module tests because the original error that was fixed occured in the map closure
+        // between Arborator and ArborView, which is part of the pipeline.
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-filename-fix.csv"
+                outdir = "results"
+
+                metadata_partition_name = "outbreak"
+                metadata_1_header = "organism"
+                metadata_2_header = "subtype"
+                metadata_3_header = "country"
+                metadata_4_header = "serovar"
+                metadata_5_header = "age"
+                metadata_6_header = "date"
+                metadata_7_header = "source"
+                metadata_8_header = "special"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check that the ArborView output is created
+            def actual_arborview1 = path("$launchDir/results/arborview/1.1.1.1_arborview.html")
+            assert actual_arborview1.exists()
+            assert actual_arborview1.text.contains("sample_name\\tsample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS1\\tS1\\t1.1.1.1\\tEscherichia coli\\tEHEC/STEC\\tCanada\\tO157:H7\\t21\\t2024/05/30\\tbeef\\tTrue\\nS2\\tS2\\t1.1.1.1\\tEscherichia coli\\tEHEC/STEC\\tThe United States\\tO157:H7\\t55\\t2024/05/21\\tmilk\\tFalse\\n")
+
+            def actual_arborview2 = path("$launchDir/results/arborview/1.1.1.2_arborview.html")
+            assert actual_arborview2.exists()
+            assert actual_arborview2.text.contains("sample_name\\tsample\\toutbreak\\torganism\\tsubtype\\tcountry\\tserovar\\tage\\tdate\\tsource\\tspecial\\nS3\\tS3\\t1.1.1.2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t14\\t2024/04/30\\tcheese\\tTrue\\nS4\\tS4\\t1.1.1.2\\tEscherichia coli\\tEPEC\\tFrance\\tO125\\t35\\t2024/04/22\\tcheese\\tTrue\\n")
+
+        }
+    }
 }

--- a/workflows/cluster_splitter.nf
+++ b/workflows/cluster_splitter.nf
@@ -120,11 +120,11 @@ workflow CLUSTER_SPLITTER {
 
     // ArborView
     trees = arborator_output.trees.flatten().map {
-        tuple(it.getParent().getBaseName(), it)
+        tuple(it.getParent().getName(), it)
     }
 
     metadata_for_trees = arborator_output.metadata.flatten().map{
-        tuple(it.getParent().getBaseName(), it)
+        tuple(it.getParent().getName(), it)
     }
 
     trees_meta = trees.join(metadata_for_trees)


### PR DESCRIPTION
## STRY0017933: Fix creation and naming of ArborView files in arboratornf pipeline

An issue that was resulting in misnaming of arborview output files Issue #38

- [x] Fix Issue
- [x] Create a nf-test to confirm fix

<!--
# phac-nml/arboratornf pull request

Many thanks for contributing to phac-nml/arboratornf!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/phac-nml/arboratornf/tree/main/.github/CONTRIBUTING.md)
-->

## nf-core checklist

- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
