### PR TITLE
Update the template arborview html file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2025-06-04
+
+### `Fix`
+
+- Updated the template ArborView html file `assets/ArborView.html` based on the the commit [046ed92](https://github.com/phac-nml/ArborView/commit/046ed92021fe37016d771c6dc69fdbe8e204a70f) to the `html/table.html` file in ArborView `v.0.1.0` that fixes rendering of plots. [PR #45](https://github.com/phac-nml/arboratornf/pull/45)
+
 ## [0.5.0] - 2025-06-03
 
 ### `Updated`
@@ -116,3 +122,4 @@ Initial release of the arboratornf pipeline to be used for running [Arborator](h
 [0.3.6]: https://github.com/phac-nml/arboratornf/releases/tag/0.3.6
 [0.4.0]: https://github.com/phac-nml/arboratornf/releases/tag/0.4.0
 [0.5.0]: https://github.com/phac-nml/arboratornf/releases/tag/0.5.0
+[0.5.1]: https://github.com/phac-nml/arboratornf/releases/tag/0.5.1

--- a/assets/ArborView.html
+++ b/assets/ArborView.html
@@ -2459,15 +2459,14 @@
                 return true;
             };
 
-            // Save some clicking
-            //if(DEBUG || TREE != __DEADBEEF__){
-            //    if(TREE != __DEADBEEF__){
-            //        drawTree(TREE);
-            ///    }else if(DEBUG){
-            //        drawTree(test_newick);
-            //
-            //    }
-            //}
+            // Check if TREE is defined or injected via the inline_arborview.py script (used by Arborator and GAS)
+            if(TREE != __DEADBEEF__){
+                // If a valid TREE variable is defined
+                if(TREE != __DEADBEEF__){
+                    // Render the actual TREE data
+                    drawTree(TREE);
+                }
+            }
 
             $("#tree-selector").change((event) => {
                 let reader = new FileReader();

--- a/nextflow.config
+++ b/nextflow.config
@@ -217,7 +217,7 @@ manifest {
     description     = """Arborator: Genomic Profile Clustering and Summary"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.5.0'
+    version         = '0.5.1'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
Small fix to issue found in the `v.0.1.0` release of ArborView causing certain html outputs to not render.

Updated the template ArborView html file `assets/ArborView.html` based on the the commit [046ed92](https://github.com/phac-nml/ArborView/commit/046ed92021fe37016d771c6dc69fdbe8e204a70f) to the `html/table.html` file in ArborView `v.0.1.0` that fixes rendering of plots. [PR #45](https://github.com/phac-nml/arboratornf/pull/45)
